### PR TITLE
Add scala3 hashtag, remove sttp and mill

### DIFF
--- a/src/scala/index.ts
+++ b/src/scala/index.ts
@@ -1,5 +1,5 @@
 const scalalang = [
-  "scala", "dotty"
+  "scala", "scala3", "dotty"
 ]
 
 const typelevel = [
@@ -12,7 +12,7 @@ const scalameta = [
 ]
 
 const softwaremill = [
-  "sttp", "scalar", "scalarconf"
+  "scalar", "scalarconf"
 ]
 
 const sbt = [
@@ -20,7 +20,7 @@ const sbt = [
 ]
 
 const lihaoi = [
-  "mill", "os-lib", "requests-scala"
+  "os-lib", "requests-scala"
 ]
 
 const lightbend = [


### PR DESCRIPTION
This PR adds filter for `scala3` hashtag as per https://github.com/polyvariant/scala-feed/issues/1 along with removing `sttp` and `mill` which generated too many false positives.