### PR TITLE
Always include posts by Scala related organization accounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN yarn install && yarn build
+RUN yarn install && yarn test && yarn build
 
 RUN rm -rf /build
 

--- a/src/FirehoseSubscription.ts
+++ b/src/FirehoseSubscription.ts
@@ -17,6 +17,7 @@ export class FirehoseSubscription extends FirehoseSubscriptionBase {
       // use only for debug purposes
       for (const post of ops.posts.creates) {
         console.log("================== [NEW POST] ==================")
+        console.log(post.author)
         console.log(post.record.text)
         console.log("================== [END POST] ==================")
       }
@@ -26,7 +27,7 @@ export class FirehoseSubscription extends FirehoseSubscriptionBase {
     const postsToCreate = ops.posts.creates
       .filter((create) => {
         // only scala related posts
-        return isAboutScala(create.record.text);
+        return isAboutScala(create.author, create.record.text);
       })
       .map((create) => {
         // map scala related posts to a db row

--- a/src/scala/accounts.ts
+++ b/src/scala/accounts.ts
@@ -1,0 +1,5 @@
+export const scalaRelatedOrganizationProfiles = [
+    "did:plc:mb6e2ashxeswusv7f7hwusp5", // scala-lang.org https://bsky.social/xrpc/com.atproto.identity.resolveHandle?handle=scala-lang.org
+    "did:plc:5nlshbn5adh3fjwzyz7xjpwl", // Scala Space    https://bsky.social/xrpc/com.atproto.identity.resolveHandle?handle=scalaspace.bsky.social
+    "did:plc:xs35x5l4ogj3g4eymh6ngcsr", // Scala Times    https://bsky.social/xrpc/com.atproto.identity.resolveHandle?handle=scalatimes.com
+]

--- a/src/scala/hashtags.ts
+++ b/src/scala/hashtags.ts
@@ -1,0 +1,46 @@
+const scalalang = [
+    "scala", "scala3", "dotty"
+]
+
+const typelevel = [
+    "cats-effect"
+]
+
+const scalameta = [
+    "munit", "scalameta", "scalafmt",
+    //  "mdoc"
+]
+
+const softwaremill = [
+    "scalar", "scalarconf"
+]
+
+const sbt = [
+    "sbt"
+]
+
+const lihaoi = [
+    "os-lib", "requests-scala"
+]
+
+const lightbend = [
+    "akka", "playframework"
+]
+
+const others = [
+    "pekko"
+]
+
+function hashTag(word: String) {
+    return `#${word}`
+}
+
+export const allHashTags =
+    scalalang.concat(typelevel,
+        scalameta,
+        softwaremill,
+        // sbt,    // sbt seems to be a thing in TV in Brasil
+        // lihaoi, // apparently people like to discuss hardware mills a lot
+        lightbend,
+        others
+    ).map(w => hashTag(w))

--- a/src/scala/index.ts
+++ b/src/scala/index.ts
@@ -1,53 +1,17 @@
-const scalalang = [
-  "scala", "scala3", "dotty"
-]
+import { allHashTags } from "./hashtags";
+import { scalaRelatedOrganizationProfiles } from "./accounts";
 
-const typelevel = [
-  "cats-effect"
-]
-
-const scalameta = [
-  "munit", "scalameta", "scalafmt",
-  //  "mdoc"
-]
-
-const softwaremill = [
-  "scalar", "scalarconf"
-]
-
-const sbt = [
-  "sbt"
-]
-
-const lihaoi = [
-  "os-lib", "requests-scala"
-]
-
-const lightbend = [
-  "akka", "playframework"
-]
-
-const others = [
-  "pekko"
-]
-
-const allHashTags =
-  scalalang.concat(typelevel,
-    scalameta,
-    softwaremill,
-    // sbt,    // sbt seems to be a thing in TV in Brasil
-    // lihaoi, // apparently people like to discuss hardware mills a lot
-    lightbend,
-    others
-  ).map(w => hashTag(w))
-
-function hashTag(word: String) {
-  return `#${word}`
-}
-
-export function isAboutScala(text: string): boolean {
+function containsRelevantHashtag(text: string): boolean {
   const input = text.toLowerCase();
   const textWords = input.split(/\s+/);
   return allHashTags.map(v => v.toLowerCase()).some(tag => textWords.includes(tag));
+}
+
+function postedByScalaOrgAccount(author: string): boolean {
+  return scalaRelatedOrganizationProfiles.includes(author);
+}
+
+export function isAboutScala(author: string, text: string): boolean {
+  return postedByScalaOrgAccount(author) || containsRelevantHashtag(text);
 }
 

--- a/tests/algos/scala-feed.test.ts
+++ b/tests/algos/scala-feed.test.ts
@@ -1,19 +1,27 @@
+import { scalaRelatedOrganizationProfiles } from '../../src/scala/accounts';
 import { isAboutScala } from '../../src/scala/index';
+
+const randomAuthorDid = "did:plc:abcde12345"
 
 describe('testing isAboutScala', () => {
   test('the #Scala hashtag should be picked up', () => {
     expect(
-      isAboutScala("#Scala")
+      isAboutScala(randomAuthorDid, "#Scala")
     ).toBe(true);
   });
   test('proper message should be qualified as Scala related', () => {
     expect(
-      isAboutScala("We've a full house at the #London #Scala OSS Hack night this Wednesday! www.meetup.com/london-scala...")
+      isAboutScala(randomAuthorDid, "We've a full house at the #London #Scala OSS Hack night this Wednesday! www.meetup.com/london-scala...")
+    ).toBe(true);
+  });
+  test('post by scala related org account should be qualified as Scala related', () => {
+    expect(
+      isAboutScala(scalaRelatedOrganizationProfiles[0], "This one doesn't have a hashtag")
     ).toBe(true);
   });
   test('empty message should not be qualified as Scala', () => {
     expect(
-      isAboutScala("")
+      isAboutScala(randomAuthorDid, "")
     ).toBe(false);
   });
 });


### PR DESCRIPTION
Resolves https://github.com/polyvariant/scala-feed/issues/3

With this PR the feed will now automatically include posts by:
- https://bsky.app/profile/scala-lang.org
- https://bsky.app/profile/scalaspace.bsky.social
- https://bsky.app/profile/scalatimes.com